### PR TITLE
Quickly sketch a solution to override the header

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -114,7 +114,7 @@ module Savon
     end
 
     def only_response
-      response = only_request.response
+      response = @only_request.response
       http.set_cookies(response.http)
       if wsse.verify_response
         WSSE::VerifySignature.new(response.http.body).verify!


### PR DESCRIPTION
**Adds two methods for overriding the XML before sending the request**

It's a quick implementation without tests for an old version of the Gem.  We had troubles getting Savon to create the correct WSSecurityCert, so we ended up needing to change the XML right before sending via HTTPI.

* Not tested